### PR TITLE
Fixes run error in heroku

### DIFF
--- a/bin/aigis
+++ b/bin/aigis
@@ -20,6 +20,6 @@ try {
   aigis.run();
 }
 catch(e) {
+  console.error(e.message);
   process.exit(1);
 }
-

--- a/lib/renderer/highlight.js
+++ b/lib/renderer/highlight.js
@@ -1,4 +1,4 @@
-var Highlights = require("Highlights");
+var Highlights = require("highlights");
 var highlighter = new Highlights();
 
 module.exports = function highlight(code, type) {


### PR DESCRIPTION
Hi.  When I used aigis in heroku, I got some error message like the following:
```
npm ERR! argv "/app/.heroku/node/bin/node" "/app/.heroku/node/bin/npm" "run" "guide"
npm ERR! Failed at the @ guide script 'aigis aigis_config.yml'.
npm ERR! Linux 3.13.0-57-generic
npm ERR! node v0.12.7
npm ERR! This is most likely a problem with the  package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     aigis aigis_config.yml
npm ERR! npm  v2.11.3
npm ERR! code ELIFECYCLE
npm ERR! @ server: `npm run guide && node app.js`
npm ERR!
npm ERR! Exit status 1
```

Also, `npm run` is here:
```
Scripts available in  via `npm run-script`:
  guide
    aigis aigis_config.yml
  server
    npm run guide && node app.js
```

After that I've added to display more detail for debug in https://github.com/pxgrid/aigis/commit/1fac34d294069d8ded2b0a9ad5462bfefb679acd, fortunately I've gotten a simple message: `{ [Error: Cannot find module 'Highlights'] code: 'MODULE_NOT_FOUND' }`. The highlights aigis required in `renderer/highlight.js` seems that [initials is in uppercase](https://github.com/pxgrid/aigis/blob/78b544470e368ffabaec87ba4fe410038b8f51aa/lib/renderer/highlight.js#L1), but more precisely [lower case was correct](https://github.com/atom/highlights/blob/master/package.json#L5). I didn't know why this error has come only in heroku, I got a silence after fixing this in https://github.com/pxgrid/aigis/commit/c22bf1f186105d4beb4ad253d8613288dd2060ec.

:sushi: < Thanks.