### PR TITLE
HTMLを整形して出力する

### DIFF
--- a/custom_template/layout.hbs
+++ b/custom_template/layout.hbs
@@ -12,8 +12,8 @@
 <div class="aigis-contents">
   <div class="aigis-contents__body">
     <h2 class="aigis-module__heading">{{name}}</h2>
-{{{modulelist}}}
-{{{modules}}}
-  {{{footer}}}
+    {{{modulelist}}}
+    {{{modules}}}
   </div>
 </div>
+{{{footer}}}

--- a/lib/injector/html.js
+++ b/lib/injector/html.js
@@ -12,7 +12,6 @@ function html(comments) {
       code = htmlBeautify(code, {
         preserve_newlines: false
       });
-      console.log(code);
       return "<div class='aigis-preview'>\n  " + code + "</div>\n\n" + codeblock;
     });
     comment.md = md;

--- a/lib/renderer/template.js
+++ b/lib/renderer/template.js
@@ -80,7 +80,12 @@ var Template = (function() {
         name: 'index'
       });
 
-      writeModules(path.join(this.options.dest, "index.html"), layoutHtml);
+      writeModules({
+        outputPath: path.join(this.options.dest,"index.html"),
+        html: layoutHtml,
+        beautify: this.options.beautify,
+        beautifyOptions: this.options.beautifyOptions
+      });
     },
     renderLayout: function(_modules, outputPath, name) {
       var root = this.getRoot(outputPath);
@@ -99,7 +104,12 @@ var Template = (function() {
         config: this.options,
         name: name,
       });
-      writeModules(outputPath, layoutHtml);
+      writeModules({
+        outputPath: outputPath,
+        html:layoutHtml,
+        beautify: this.options.beautify,
+        beautifyOptions: this.options.beautifyOptions
+      });
     },
     renderColor: function() {
       var html = this.templates.colorpalette({colors:this.colors});
@@ -114,7 +124,12 @@ var Template = (function() {
         name: 'color'
       });
 
-      writeModules(path.join(this.options.dest, "color.html"), layoutHtml);
+      writeModules({
+        outputPath: path.join(this.options.dest, "color.html"),
+        html: layoutHtml,
+        beautify: this.options.beautify,
+        beautifyOptions: this.options.beautifyOptions
+      });
     },
     write: function() {
       this.render();

--- a/lib/writer/modules.js
+++ b/lib/writer/modules.js
@@ -1,6 +1,29 @@
 var fs = require("fs-extra");
+var htmlBeautify = require("js-beautify").html;
+var DEFAULT_OPTIONS = {
+  max_preserve_newlines: 1,
+  indent_size: 2,
+  end_with_newline: true,
+  indent_inner_html: true,
+  extra_liners: []
+};
 
-function writeModules(outputPath, html) {
+/*
+* {Object} options
+* {String} options.outputPath
+* {String} options.html
+* {Boolean} options.beautify
+* {Object} options.beautifyOptions
+*/
+function writeModules(options) {
+  var html = options.html;
+  var outputPath = options.outputPath;
+  options.beautifyOptions = options.beautifyOptions || {};
+  var beautifyOptions = _.extend(DEFAULT_OPTIONS, options.beautifyOptions);
+
+  if (options.beautify !== false) {
+    html = htmlBeautify(html, beautifyOptions);
+  }
   fs.outputFileSync(outputPath, html);
 }
 


### PR DESCRIPTION
`aigis_config.yml`の`beautify`オプションに`false`を設定すると無効にできる。

整形に使ってる`js-beautify`に渡すオプションは`beautifyOptions`で上書きできる。
デフォルトのオプションは👇

```js
var DEFAULT_OPTIONS = {
  max_preserve_newlines: 1,
  indent_size: 2,
  end_with_newline: true,
  indent_inner_html: true,
  extra_liners: []
};
```