### PR TITLE
Fixes display errors

### DIFF
--- a/lib/Aigis.js
+++ b/lib/Aigis.js
@@ -48,7 +48,9 @@ var Aigis = (function() {
         this.readCSSFiles(this.options.source)
           .then(this._setup.bind(this))
           .then(resolve)
-          .catch(reject);
+          .catch(function (e) {
+            console.error(e.formatted);
+          });
       }.bind(this));
     },
 


### PR DESCRIPTION
To display an error for https://github.com/pxgrid/aigis/issues/55, I just updated a error handling on Promise way in `lib/Aigis.js`. Also the sanity log `console.log("\n-------- target file --------");` should be displayed when the variable cssString is exist. So these commits doesn't fix #55, just for displaying en error correctly.

Here is an example to reproduce #55 and that's on https://github.com/watilde/aigis-test-55:
```
> npm run gulp aigis

> aigis@1.0.0 gulp /Users/daijiro/Development/aigis-test-55
> gulp "aigis"

[11:27:24] Using gulpfile ~/Development/aigis-test-55/gulpfile.js
[11:27:24] Starting 'aigis'...
[11:27:24] Finished 'aigis' after 8.3 ms
[11:27:24] config file: /Users/daijiro/Development/aigis-test-55/aigis_config.yml
Error: File to import not found or unreadable: bourbon
       Parent style sheet: stdin
        on line 1 of stdin
>> @import "bourbon";
```
you need to run `npm link` things if you'd like to reproduce this like the above. Let me know if you have any question please. Thanks.