### PR TITLE
Fix typo in documents

### DIFF
--- a/docs/en/category/Usage/CLI/index.html
+++ b/docs/en/category/Usage/CLI/index.html
@@ -94,7 +94,7 @@ Examples<span class="token punctuation" >:</span>
 <tbody>
 <tr>
 <td  ><code>--engine</code></td>
-<td  ><code>-c</code></td>
+<td  ><code>-e</code></td>
 <td  >ejs, jade, hbs</td>
 </tr>
 </tbody>

--- a/docs/en/category/Usage/index.html
+++ b/docs/en/category/Usage/index.html
@@ -94,7 +94,7 @@ Examples<span class="token punctuation" >:</span>
 <tbody>
 <tr>
 <td  ><code>--engine</code></td>
-<td  ><code>-c</code></td>
+<td  ><code>-e</code></td>
 <td  >ejs, jade, hbs</td>
 </tr>
 </tbody>

--- a/docs/jp/category/Usage/CLI/index.html
+++ b/docs/jp/category/Usage/CLI/index.html
@@ -94,7 +94,7 @@ Examples<span class="token punctuation" >:</span>
 <tbody>
 <tr>
 <td  ><code>--engine</code></td>
-<td  ><code>-c</code></td>
+<td  ><code>-e</code></td>
 <td  >ejs, jade, hbs</td>
 </tr>
 </tbody>

--- a/docs/jp/category/Usage/index.html
+++ b/docs/jp/category/Usage/index.html
@@ -94,7 +94,7 @@ Examples<span class="token punctuation" >:</span>
 <tbody>
 <tr>
 <td  ><code>--engine</code></td>
-<td  ><code>-c</code></td>
+<td  ><code>-e</code></td>
 <td  >ejs, jade, hbs</td>
 </tr>
 </tbody>

--- a/src/en/Usage/cli.md
+++ b/src/en/Usage/cli.md
@@ -63,7 +63,7 @@ Examples:
 ### options
 |name|alias|value|
 |---|---|---|
-|`--engine`|`-c`|ejs, jade, hbs|
+|`--engine`|`-e`|ejs, jade, hbs|
 
 
 */

--- a/src/jp/Usage/cli.md
+++ b/src/jp/Usage/cli.md
@@ -63,7 +63,7 @@ Examples:
 ### オプション
 |name|alias|value|
 |---|---|---|
-|`--engine`|`-c`|ejs, jade, hbs|
+|`--engine`|`-e`|ejs, jade, hbs|
 
 
 */


### PR DESCRIPTION
The `--engine` cmd option shorthand is `-e`.
https://github.com/pxgrid/aigis/blob/618d59/bin/cmd/init.js#L2-L3