### PR TITLE
Add lang_prefix options

### DIFF
--- a/examples/aigis_config.yml
+++ b/examples/aigis_config.yml
@@ -66,6 +66,7 @@ output_collection:
 
 highlight: true
 highlight_theme: monokai
+lang_prefix: 'language-'
 
 # plugin directory
 # plugin: ./plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-aigis",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "For documenting CSS and generating styleguide",
   "homepage": "https://pxgrid.github.io/aigis",
   "author": {
@@ -24,7 +24,7 @@
     "url": "https://github.com/pxgrid/aigis/issues"
   },
   "dependencies": {
-    "aigis-marked": "0.1.1",
+    "aigis-marked": "0.2.0",
     "bluebird": "^2.9.14",
     "colors": "^1.1.2",
     "detect-css-colors": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/pxgrid/aigis/issues"
   },
   "dependencies": {
-    "aigis-marked": "0.2.0",
+    "aigis-marked": "^0.2.1",
     "bluebird": "^2.9.14",
     "colors": "^1.1.2",
     "detect-css-colors": "^1.0.1",


### PR DESCRIPTION
ref: #89 

We can change codeblock prefix via `aigis_config.yml`. Also `lang_prefix` defaults value is `'language-'`.

```yaml
lang_prefix: 'language-'
```

example result:

![image](https://cloud.githubusercontent.com/assets/1995370/19507784/0de41b96-9610-11e6-9c42-05c419b53e71.png)




