### PR TITLE
use a variable, config.name, instead of hard-coded 'index'

### DIFF
--- a/examples/template_ejs/sidemenu.ejs
+++ b/examples/template_ejs/sidemenu.ejs
@@ -1,6 +1,6 @@
 <div class="aigis-sidemenu">
   <header class="aigis-header">
-    <a href="<%- root %>index.html">Index</a>
+    <a href="<%- root %>index.html"><%- config.name %></a>
   </header>
   <h2 class="aigis-sidemenu__heading">Category</h2>
   <nav class="aigis-categoryList">


### PR DESCRIPTION
I 've found that the value of `name` variable defined in a `aigis_config.yml` won't come out when ejs is selected as a template engine. 
I'm unsure, but hope this PR will fix it :smiley: 