### PR TITLE
Enabling handlebars include to pass contextual params

### DIFF
--- a/examples/aigis_config.yml
+++ b/examples/aigis_config.yml
@@ -39,6 +39,9 @@ template_engine: ejs
 # It must contain 'layout.xxx' and 'index.xxx' (.ejs or .jade or .hbs)
 template_dir: ./template_ejs
 
+# data passed to the template comes either from the config or by params
+template_global_data: true
+
 # Aigis displays logs
 log: false
 
@@ -67,6 +70,7 @@ output_collection:
 highlight: true
 highlight_theme: monokai
 lang_prefix: 'language-'
+
 
 # plugin directory
 # plugin: ./plugin

--- a/lib/plugin/src/transform/hbs.js
+++ b/lib/plugin/src/transform/hbs.js
@@ -11,20 +11,24 @@ function transform(components, options) {
     var ext = path.extname(includePath).length ===0 ? '.hbs' : '';
     var filePath = path.join(options.component_dir, includePath + ext);
     var template = fs.readFileSync(filePath, 'utf-8');
+    var data = options.template_global_data ? this : params.hash;
+    
     template = hbs.compile(template);
-    return new hbs.SafeString(template(this));
+    
+    return new hbs.SafeString(template(data));
   });
-
+  
   var reg_block = /^`{3}(hbs|handlebars)$[\s\S]*?^`{3}$/gm;
   var reg_start = /^`{3}(hbs|handlebars)$/m;
   var reg_end = /^`{3}$/m;
-
+  
   return _.map(components, function(component) {
     var md = component.md.replace(reg_block, function(codeblock) {
       var code = codeblock.replace(reg_start, '').replace(reg_end, '');
-
+      
       if (component.config.compile === true) {
-        code = hbs.compile(code)(component.config);
+        var data = options.template_global_data ? component.config : {};
+        code = hbs.compile(code)(data);
         code = htmlBeautify(code, {
           preserve_newlines: false
         });


### PR DESCRIPTION
Before we were able to pass only the configuration data object.
Often, we need to include several times the same component with different label. By having a single data object, it was not possible.

Here is the new way for passing data using contextual params.

{{include './button.html' label='Buy'}}

button.html
`
<button>{{label}}</button>
`