### PR TITLE
allow handlebars component nesting

### DIFF
--- a/lib/plugin/src/transform/hbs.js
+++ b/lib/plugin/src/transform/hbs.js
@@ -15,6 +15,10 @@ function transform(components, options) {
     
     template = hbs.compile(template);
     
+    if(typeof params.fn === 'function') {
+      data.yield = params.fn(this);
+    }
+    
     return new hbs.SafeString(template(data));
   });
   


### PR DESCRIPTION
In some cases, with more complex components like media-object, we need to split them into small pieces.

Potentially, I can have several sections and that can contains "custom html" and passing everything using parameter is not flexible enough.

Here is an example with the code changes using nested templates:

{{{yield}}} is the helper that renders everything within a component helper

**media-object.scss**
```hbs
{{#include './components/media-object/container'}}
    {{#include './components/media-object/section' align="middle"}}
        <img src="https://dummyimage.com/50x50/ededed/9b9b9b.jpg&text=IMG"/>
    {{/include}}
    {{#include './components/media-object/section'}}
        <h4>Dreams feel real while we're in them.</h4>
        <p>I'm going to improvise. Listen, there's something you should know about me... about inception. An idea is
        like a virus, resilient, highly contagious. The smallest seed of an idea can grow. It can grow to define or
        destroy you.</p>
    {{/include}}
{{/include}}
```

**components/media-object/container.hbs**
```hbs
<div class="c-media-object">
    {{{yield}}}
</div>
```
**components/media-object/section.hbs**
```
<div class="c-media-object__section {{#if align}}c-media-object__section--{{align}}{{/if}}">
    {{{yield}}}
</div>
```
